### PR TITLE
Add a git ls after fetch

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -688,6 +688,11 @@ func addWorktreeAndSwap(ctx context.Context, gitRoot, dest, branch, rev string, 
 		return err
 	}
 
+	// ls to record in logs what commit was fetched
+	if _, err := runCommand(ctx, gitRoot, *flGitCmd, "log", "-n1"); err != nil {
+		return err
+	}
+
 	// GC clone
 	if _, err := runCommand(ctx, gitRoot, *flGitCmd, "gc", "--prune=all"); err != nil {
 		return err


### PR DESCRIPTION
Adding a git ls after fetch to record the commit that was fetched recently.
This would be useful to debug hard to reproduce potential race conditions b/w git ls-remote and git fetch.

We ran into a condition where git reset hard failed with "fatal: could not parse object <SOME REF>"

